### PR TITLE
renumber update

### DIFF
--- a/PANDORA/PMHC/Model.py
+++ b/PANDORA/PMHC/Model.py
@@ -1,4 +1,6 @@
 from Bio.PDB import PDBParser
+from Bio.PDB.Polypeptide import PPBuilder
+from Bio import pairwise2
 import os
 from Bio.PDB import PDBIO
 import PANDORA

--- a/PANDORA/PMHC/Model.py
+++ b/PANDORA/PMHC/Model.py
@@ -405,12 +405,9 @@ def get_Gdomain_lzone(ref_pdb, output_dir, MHC_class):
 
 def remove_C_like_domain(pdb):
     '''Removes the C-like domain from a MHC struture and keeps only the G domain
-
     Args:
         pdb: (Bio.PDB): Bio.PDB object with chains names M (N for MHCII) and P
-
     Returns: (Bio.PDB): Bio.PDB object without the C-like domain
-
     '''
 
     # If MHCII, remove the C-like domain from the M-chain (res 80 and higher) and the N-chain (res 90 and higher)
@@ -430,10 +427,8 @@ def remove_C_like_domain(pdb):
     if 'N' not in [chain.id for chain in pdb.get_chains()]:
         for chain in pdb.get_chains():
             if chain.id == 'M':
-                for res in chain:
-                    if res.id[1] > 180:
-                        chain.detach_child(res.id)
-
+                need_to_be_removed = [res.id for res in chain if res.id[1] > 180]
+                _ = [chain.detach_child(x) for x in need_to_be_removed]
     return pdb
 
 #ValueError: Invalid column name lzone. Possible names are

--- a/PANDORA/PMHC/Model.py
+++ b/PANDORA/PMHC/Model.py
@@ -217,25 +217,61 @@ def merge_chains(pdb):
     return pdb
 
 
-def renumber(pdb):
-    ''' Renumbers the pdb. Each chain starts at 1
+def renumber(pdb_ref, pdb_decoy):
+    ''' aligns two pdb's and renumber them accordingly.
 
     Args:
-        pdb: Bio.PDb object
+        pdb_ref:   Bio.PDB object
+        pdb_decoy: Bio.PDB object
+        
 
-    Returns:Bio.PDb object with renumbered residues
+    Returns: Bio.PDB objects with renumbered residues
 
     '''
-    for chain in pdb.get_chains():
-        nr = 1
-        for res in chain:
-            res.id = ('X', nr, res.id[2])
-            nr += 1
-    for chain in pdb.get_chains():
-        for res in chain:
-            res.id = (' ', res.id[1], ' ')
+    ppb=PPBuilder()
+    ref_sequences = [[chain.id, ppb.build_peptides(chain)[0].get_sequence()]
+                      for chain in pdb_ref.get_chains()]
+    ref_sequences.sort()
+    decoy_sequences = [[chain.id, ppb.build_peptides(chain)[0].get_sequence()]
+                      for chain in pdb_decoy.get_chains()]
+    decoy_sequences.sort()
+    
+    assert(len(ref_sequences) == len(decoy_sequences))
+    
+    for ind in range(len(ref_sequences)):
+        pair = pairwise2.align.globalxx(ref_sequences[ind][1], decoy_sequences[ind][1])[0]
+        ref_sequences[ind][1]   = pair.seqA
+        decoy_sequences[ind][1] = pair.seqB
+    
+    def assign(pdb, pdb_sequences):
+        ''' Renumbers the pdb using aligned sequences. 
 
-    return pdb
+        Args:
+            pdb_ref:   Bio.PDB object
+            pdb_decoy: Bio.PDB object
+            
+
+        Returns: Bio.PDB objects with renumbered residues
+
+        '''
+        for chain in pdb.get_chains():
+            for seq in pdb_sequences:
+                if chain.id == seq[0]:
+                    tel = 0
+                    for res in chain:
+                        while seq[1][tel] == '-':
+                            tel += 1    
+                        res.id = ('X', tel+1, res.id[2])
+                        tel += 1
+        for chain in pdb.get_chains():
+            for res in chain:
+                res.id = (' ', res.id[1], ' ')
+        return pdb
+
+    pdb_ref = assign(pdb_ref, ref_sequences)
+    pdb_decoy = assign(pdb_decoy, decoy_sequences)
+
+    return pdb_ref, pdb_decoy
 
 # decoy = PDBParser(QUIET=True).get_structure('MHC', y.model_path)
 #
@@ -290,10 +326,9 @@ def homogenize_pdbs(decoy, ref, output_dir, target_id = 'MHC', anchors =False, f
 
     # merge chains of the decoy
     decoy = merge_chains(decoy)
-    decoy = renumber(decoy)
     # merge chains of the reference
     ref = merge_chains(ref)
-    ref = renumber(ref)
+    ref, decoy = renumber(ref, decoy)
 
     # Write pdbs
     decoy_path = '%s/%s_decoy.pdb' % (output_dir, target_id)


### PR DESCRIPTION
Replaced the "renumber" function. Now this functions accepts 2 Bio.PDB objects, aligns them per chain, and then renumbers the residues accordingly.
Also modified the line where the renumber function is called.
Also changed the "remove_C_like_domain" function. It did not cut at all, now it does.